### PR TITLE
chore(easysql): 使用由EasySQL提供的静态方法直接关闭数据管理器。

### DIFF
--- a/EasySqlTutorialPlugin/src/main/java/com/senko/easysqltutorial/EasySqlTutorial.java
+++ b/EasySqlTutorialPlugin/src/main/java/com/senko/easysqltutorial/EasySqlTutorial.java
@@ -39,8 +39,10 @@ public final class EasySqlTutorial extends JavaPlugin {
         getLogger().info("关闭插件中。。。。");
         //关闭数据源中的连接池
         if (Objects.nonNull(sqlManager)) {
-            ((HikariDataSource) sqlManager.getDataSource()).close();
-            getLogger().info("正在关闭数据源中的连接池");
+            // 使用由EasySQL提供的静态方法直接关闭数据管理器。
+            EasySQL.shutdownManager(sqlManager); 
+            // ((HikariDataSource) sqlManager.getDataSource()).close();
+            // getLogger().info("正在关闭数据源中的连接池");
         }
     }
 


### PR DESCRIPTION
一般的情况下，可以直接使用  已经提供的 `EasySQL#shutdownManager()` 方法直接关闭一个SQLManager实例。

若有特殊需求，可使用 `EasySQL#shutdownManager(manager,forceClose,output)` 方法。